### PR TITLE
mandlebrot -> mandelbrot

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -2084,17 +2084,17 @@ plane to converge:
 ```python
 # Determine whether the specific location diverges.
 # Solve for z = z^2 + c in the complex plane.
-def mandleconverger(real imag iters creal cimag)
+def mandelconverger(real imag iters creal cimag)
   if iters > 255 | (real*real + imag*imag > 4) then
     iters
   else
-    mandleconverger(real*real - imag*imag + creal,
+    mandelconverger(real*real - imag*imag + creal,
                     2*real*imag + cimag,
                     iters+1, creal, cimag);
 
 # Return the number of iterations required for the iteration to escape
-def mandleconverge(real imag)
-  mandleconverger(real, imag, 0, real, imag);
+def mandelconverge(real imag)
+  mandelconverger(real, imag, 0, real, imag);
 ```
 
 Our ``mandelconverge`` function returns the number of iterations that it takes for a complex orbit to escape,
@@ -2103,12 +2103,12 @@ two-dimensional plane, we can see the Mandelbrot set. Given that we are limited 
 amazing graphical output is limited, but we can whip together something using the density plotter above:
 
 ```python
-# Compute and plot the mandlebrot set with the specified 2 dimensional range
+# Compute and plot the mandelbrot set with the specified 2 dimensional range
 # info.
 def mandelhelp(xmin xmax xstep   ymin ymax ystep)
   for y = ymin, y < ymax, ystep in (
     (for x = xmin, x < xmax, xstep in
-       printdensity(mandleconverge(x,y)))
+       printdensity(mandelconverge(x,y)))
     : putchard(10)
   );
 
@@ -2120,7 +2120,7 @@ def mandel(realstart imagstart realmag imagmag)
 ```
 
 
-Given this, we can try plotting out the mandlebrot set! Lets try it out:
+Given this, we can try plotting out the mandelbrot set! Lets try it out:
 
 ```python
 


### PR DESCRIPTION
Made the spelling consistent.
