### PR TITLE
Fix differences between source & tutorial

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -651,10 +651,10 @@ references of values.
 
 ```haskell
 local ::  Name -> Operand
-local = LocalReference
+local = LocalReference double
 
 externf :: Name -> Operand
-externf = ConstantOperand . C.GlobalReference
+externf = ConstantOperand . C.GlobalReference double
 ```
 
 Our function ``externf`` will emit a named value which refers to a toplevel function (``@add``) in our module

--- a/tutorial.md
+++ b/tutorial.md
@@ -880,7 +880,7 @@ discuss these functions in more depth in the next chapter.
 codegen :: AST.Module -> [S.Expr] -> IO AST.Module
 codegen mod fns = withContext $ \context ->
   liftError $ withModuleFromAST context newast $ \m -> do
-    llstr <- moduleString m
+    llstr <- moduleLLVMAssembly m
     putStrLn llstr
     return newast
   where

--- a/tutorial.md
+++ b/tutorial.md
@@ -720,16 +720,16 @@ values.
 
 ```haskell
 fadd :: Operand -> Operand -> Codegen Operand
-fadd a b = instr $ FAdd a b []
+fadd a b = instr $ FAdd NoFastMathFlags a b []
 
 fsub :: Operand -> Operand -> Codegen Operand
-fsub a b = instr $ FSub a b []
+fsub a b = instr $ FSub NoFastMathFlags a b []
 
 fmul :: Operand -> Operand -> Codegen Operand
-fmul a b = instr $ FMul a b []
+fmul a b = instr $ FMul NoFastMathFlags a b []
 
 fdiv :: Operand -> Operand -> Codegen Operand
-fdiv a b = instr $ FDiv a b []
+fdiv a b = instr $ FDiv NoFastMathFlags a b []
 ```
 
 On top of the basic arithmetic functions we'll add the basic control flow operations which will allow us to


### PR DESCRIPTION
There are a few missing parameters in the tutorial that are present in the source code.