### PR TITLE
Update for LLVM 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,59 @@
-language: haskell
+# NB: don't set `language: haskell` here
 
+# The following enables several GHC versions to be tested; often it's enough to test only against
+# the last release in a major GHC version. Feel free to omit lines listings versions you don't
+# need/want testing for.
+env:
+ - CABALVER=1.18 GHCVER=7.6.3 LLVMVER=3.5
+ - CABALVER=1.18 GHCVER=7.8.4 LLVMVER=3.5
+ - CABALVER=1.22 GHCVER=7.10.1 LLVMVER=3.5
+ - CABALVER=1.22 GHCVER=7.10.2 LLVMVER=3.5
+ # - CABALVER=head GHCVER=head   # see section about GHC HEAD snapshots
+
+# Note: the distinction between `before_install` and `install` is not important.
+before_install:
+ - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
+ - travis_retry sudo apt-get update
+ - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER # see note about happy/alex
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH:$HOME/.cabal/bin:$PATH
+ - |
+   if [ $GHCVER = "head" ] || [ ${GHCVER%.*} = "7.8" ] || [ ${GHCVER%.*} = "7.10" ]; then
+     travis_retry sudo apt-get install happy-1.19.4 alex-3.1.3
+     export PATH=/opt/alex/3.1.3/bin:/opt/happy/1.19.4/bin:$PATH
+   else
+     travis_retry sudo apt-get install happy alex
+   fi
+
+ # update gcc and g++
+ - gcc --version
+ - g++ --version
+ - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+ - sudo apt-get update -qq
+ - sudo apt-get install -qq g++-4.8 gcc-4.8
+ - gcc --version
+ - g++ --version
+ - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 90
+ - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
+ - gcc --version
+ - g++ --version
+
+ # update llvm
+ - wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key|sudo apt-key add -
+ - travis_retry sudo add-apt-repository "deb http://llvm.org/apt/precise/ llvm-toolchain-precise main"
+ - travis_retry sudo add-apt-repository "deb http://llvm.org/apt/precise/ llvm-toolchain-precise-$LLVMVER main"
+ - travis_retry sudo apt-get update
+ - sudo apt-get install libedit-dev -y
+ - sudo apt-get install -y llvm-$LLVMVER llvm-$LLVMVER-dev
+ - sudo ln -s /usr/bin/opt-$LLVMVER /usr/bin/opt
+ - export PATH="/usr/bin:$PATH"
+
+install:
+ - cabal --version
+ - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+ - travis_retry cabal update
+ - travis_retry cabal install -j4 --only-dependencies
+
+# Here starts the actual work to be performed for the package under test; any command which exits
+# with a non-zero exit code causes the build to fail.
+script:
+  - cabal install

--- a/kaleidoscope.cabal
+++ b/kaleidoscope.cabal
@@ -27,8 +27,8 @@ executable chapter2
   build-depends:
       base                 >= 4.6
     , haskeline            >= 0.7.1.2
-    , llvm-general         == 3.4.4.*
-    , llvm-general-pure    == 3.4.4.*
+    , llvm-general         == 3.5.0.*
+    , llvm-general-pure    == 3.5.0.*
     , mtl
     , parsec               >= 3.1
     , transformers
@@ -40,8 +40,8 @@ executable chapter3
   build-depends:
       base                 >= 4.6
     , haskeline            >= 0.7.1.2
-    , llvm-general         == 3.4.4.*
-    , llvm-general-pure    == 3.4.4.*
+    , llvm-general         == 3.5.0.*
+    , llvm-general-pure    == 3.5.0.*
     , mtl                  >= 2.2
     , parsec               >= 3.1
     , transformers
@@ -54,8 +54,8 @@ executable chapter4
   build-depends:
       base                 >= 4.6
     , haskeline            >= 0.7.1.2
-    , llvm-general         == 3.4.4.*
-    , llvm-general-pure    == 3.4.4.*
+    , llvm-general         == 3.5.0.*
+    , llvm-general-pure    == 3.5.0.*
     , mtl                  >= 2.2
     , parsec               >= 3.1
     , transformers
@@ -68,8 +68,8 @@ executable chapter5
   build-depends:
       base                 >= 4.6
     , haskeline            >= 0.7.1.2
-    , llvm-general         == 3.4.4.*
-    , llvm-general-pure    == 3.4.4.*
+    , llvm-general         == 3.5.0.*
+    , llvm-general-pure    == 3.5.0.*
     , mtl                  >= 2.2
     , parsec               >= 3.1
     , transformers
@@ -82,8 +82,8 @@ executable chapter6
   build-depends:
       base                 >= 4.6
     , haskeline            >= 0.7.1.2
-    , llvm-general         == 3.4.4.*
-    , llvm-general-pure    == 3.4.4.*
+    , llvm-general         == 3.5.0.*
+    , llvm-general-pure    == 3.5.0.*
     , mtl                  >= 2.2
     , parsec               >= 3.1
     , transformers
@@ -96,8 +96,8 @@ executable chapter7
   build-depends:
       base                 >= 4.6
     , haskeline            >= 0.7.1.2
-    , llvm-general         == 3.4.4.*
-    , llvm-general-pure    == 3.4.4.*
+    , llvm-general         == 3.5.0.*
+    , llvm-general-pure    == 3.5.0.*
     , mtl                  >= 2.2
     , parsec               >= 3.1
     , transformers
@@ -109,8 +109,8 @@ library
   build-depends:       
       base                 >= 4.6
     , haskeline            >= 0.7.1.2
-    , llvm-general         == 3.4.4.*
-    , llvm-general-pure    == 3.4.4.*
+    , llvm-general         == 3.5.0.*
+    , llvm-general-pure    == 3.5.0.*
     , mtl
     , transformers
 

--- a/src/chapter3/Codegen.hs
+++ b/src/chapter3/Codegen.hs
@@ -251,7 +251,7 @@ toArgs = map (\x -> (x, []))
 
 -- Effects
 call :: Operand -> [Operand] -> Codegen Operand
-call fn args = instr $ Call False CC.C [] (Right fn) (toArgs args) [] []
+call fn args = instr $ Call Nothing CC.C [] (Right fn) (toArgs args) [] []
 
 alloca :: Type -> Codegen Operand
 alloca ty = instr $ Alloca ty Nothing 0 []

--- a/src/chapter4/Codegen.hs
+++ b/src/chapter4/Codegen.hs
@@ -251,7 +251,7 @@ toArgs = map (\x -> (x, []))
 
 -- Effects
 call :: Operand -> [Operand] -> Codegen Operand
-call fn args = instr $ Call False CC.C [] (Right fn) (toArgs args) [] []
+call fn args = instr $ Call Nothing CC.C [] (Right fn) (toArgs args) [] []
 
 alloca :: Type -> Codegen Operand
 alloca ty = instr $ Alloca ty Nothing 0 []

--- a/src/chapter5/Codegen.hs
+++ b/src/chapter5/Codegen.hs
@@ -251,7 +251,7 @@ toArgs = map (\x -> (x, []))
 
 -- Effects
 call :: Operand -> [Operand] -> Codegen Operand
-call fn args = instr $ Call False CC.C [] (Right fn) (toArgs args) [] []
+call fn args = instr $ Call Nothing CC.C [] (Right fn) (toArgs args) [] []
 
 alloca :: Type -> Codegen Operand
 alloca ty = instr $ Alloca ty Nothing 0 []

--- a/src/chapter6/Codegen.hs
+++ b/src/chapter6/Codegen.hs
@@ -251,7 +251,7 @@ toArgs = map (\x -> (x, []))
 
 -- Effects
 call :: Operand -> [Operand] -> Codegen Operand
-call fn args = instr $ Call False CC.C [] (Right fn) (toArgs args) [] []
+call fn args = instr $ Call Nothing CC.C [] (Right fn) (toArgs args) [] []
 
 alloca :: Type -> Codegen Operand
 alloca ty = instr $ Alloca ty Nothing 0 []

--- a/src/chapter7/Codegen.hs
+++ b/src/chapter7/Codegen.hs
@@ -270,7 +270,7 @@ toArgs = map (\x -> (x, []))
 
 -- Effects
 call :: Operand -> [Operand] -> Codegen Operand
-call fn args = instr $ Call False CC.C [] (Right fn) (toArgs args) [] []
+call fn args = instr $ Call Nothing CC.C [] (Right fn) (toArgs args) [] []
 
 alloca :: Type -> Codegen Operand
 alloca ty = instr $ Alloca ty Nothing 0 []

--- a/tutorial.md
+++ b/tutorial.md
@@ -753,7 +753,7 @@ allocated uninitialized value of the given type.
 
 ```haskell
 call :: Operand -> [Operand] -> Codegen Operand
-call fn args = instr $ Call False CC.C [] (Right fn) (toArgs args) [] []
+call fn args = instr $ Call Nothing CC.C [] (Right fn) (toArgs args) [] []
 
 alloca :: Type -> Codegen Operand
 alloca ty = instr $ Alloca ty Nothing 0 []


### PR DESCRIPTION
`llvm-general` and `llvm-general-pure` have been updated for llvm-3.5.

**PS**: I made these changes following just the types. The changes are very minor, and I don't have a clue as to the semantic results. I was waiting for an update to begin the tutorial, as Arch provides `llvm35` in the repositories.

For your reference, this is the error that results without this patch (one for each chapter 3-7):

```
src/chapter3/Codegen.hs:254:29:
    Couldn't match expected type ‘Maybe TailCallKind’
                with actual type ‘Bool’
    In the first argument of ‘Call’, namely ‘False’
    In the second argument of ‘($)’, namely
      ‘Call False CC.C [] (Right fn) (toArgs args) [] []’
```