### PR TITLE
Modify build dependence of llvm-general. Change Control.Monad.Error t…

### DIFF
--- a/kaleidoscope.cabal
+++ b/kaleidoscope.cabal
@@ -27,7 +27,7 @@ executable chapter2
   build-depends:
       base                 >= 4.6
     , haskeline            >= 0.7.1.2
-    , llvm-general         == 3.5.0.*
+    , llvm-general         >= 3.5.0.0 && < 3.5.2.0
     , llvm-general-pure    == 3.5.0.*
     , mtl
     , parsec               >= 3.1
@@ -40,7 +40,7 @@ executable chapter3
   build-depends:
       base                 >= 4.6
     , haskeline            >= 0.7.1.2
-    , llvm-general         == 3.5.0.*
+    , llvm-general         >= 3.5.0.0 && < 3.5.2.0
     , llvm-general-pure    == 3.5.0.*
     , mtl                  >= 2.2
     , parsec               >= 3.1
@@ -54,7 +54,7 @@ executable chapter4
   build-depends:
       base                 >= 4.6
     , haskeline            >= 0.7.1.2
-    , llvm-general         == 3.5.0.*
+    , llvm-general         >= 3.5.0.0 && < 3.5.2.0
     , llvm-general-pure    == 3.5.0.*
     , mtl                  >= 2.2
     , parsec               >= 3.1
@@ -68,7 +68,7 @@ executable chapter5
   build-depends:
       base                 >= 4.6
     , haskeline            >= 0.7.1.2
-    , llvm-general         == 3.5.0.*
+    , llvm-general         >= 3.5.0.0 && < 3.5.2.0
     , llvm-general-pure    == 3.5.0.*
     , mtl                  >= 2.2
     , parsec               >= 3.1
@@ -82,7 +82,7 @@ executable chapter6
   build-depends:
       base                 >= 4.6
     , haskeline            >= 0.7.1.2
-    , llvm-general         == 3.5.0.*
+    , llvm-general         >= 3.5.0.0 && < 3.5.2.0
     , llvm-general-pure    == 3.5.0.*
     , mtl                  >= 2.2
     , parsec               >= 3.1
@@ -96,7 +96,7 @@ executable chapter7
   build-depends:
       base                 >= 4.6
     , haskeline            >= 0.7.1.2
-    , llvm-general         == 3.5.0.*
+    , llvm-general         >= 3.5.0.0 && < 3.5.2.0
     , llvm-general-pure    == 3.5.0.*
     , mtl                  >= 2.2
     , parsec               >= 3.1
@@ -104,13 +104,12 @@ executable chapter7
     , containers           >= 0.4
   hs-source-dirs:      src/chapter7
 
-library 
+library
   default-language:    Haskell2010
-  build-depends:       
+  build-depends:
       base                 >= 4.6
     , haskeline            >= 0.7.1.2
-    , llvm-general         == 3.5.0.*
+    , llvm-general         >= 3.5.0.0 && < 3.5.2.0
     , llvm-general-pure    == 3.5.0.*
     , mtl
     , transformers
-

--- a/src/chapter4/Emit.hs
+++ b/src/chapter4/Emit.hs
@@ -12,7 +12,7 @@ import qualified LLVM.General.AST.FloatingPointPredicate as FP
 
 import Data.Word
 import Data.Int
-import Control.Monad.Error
+import Control.Monad.Except
 import Control.Applicative
 import qualified Data.Map as Map
 

--- a/src/chapter5/Emit.hs
+++ b/src/chapter5/Emit.hs
@@ -12,7 +12,7 @@ import qualified LLVM.General.AST.FloatingPointPredicate as FP
 
 import Data.Word
 import Data.Int
-import Control.Monad.Error
+import Control.Monad.Except
 import Control.Applicative
 import qualified Data.Map as Map
 

--- a/src/chapter6/Emit.hs
+++ b/src/chapter6/Emit.hs
@@ -12,7 +12,7 @@ import qualified LLVM.General.AST.FloatingPointPredicate as FP
 
 import Data.Word
 import Data.Int
-import Control.Monad.Error
+import Control.Monad.Except
 import Control.Applicative
 import qualified Data.Map as Map
 

--- a/src/chapter7/Emit.hs
+++ b/src/chapter7/Emit.hs
@@ -27,7 +27,7 @@ import LLVM.General.ExecutionEngine ( withMCJIT, withModuleInEngine, getFunction
 
 import Data.Word
 import Data.Int
-import Control.Monad.Error
+import Control.Monad.Except
 import Control.Applicative
 import qualified Data.Map as Map
 


### PR DESCRIPTION
It can be built well with llvm-general-3.5.1.0, and Control.Monad.Error is deprecated.