### PR TITLE
Fix some typos and grammar

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -147,7 +147,7 @@ atan2(sin(.4), cos(42))
 A more interesting example is included in Chapter 6 where we write a little Kaleidoscope application that
 displays a Mandelbrot Set at various levels of magnification.
 
-Lets dive into the implementation of this language!
+Let's dive into the implementation of this language!
 
 LLVM Introduction
 -----------------
@@ -1126,7 +1126,7 @@ runJIT mod = do
 
 ```
 
-Now that we have reasonable code coming out of our front-end, lets talk about executing it!
+Now that we have reasonable code coming out of our front-end, let's talk about executing it!
 
 Adding a JIT Compiler
 ---------------------
@@ -1293,7 +1293,7 @@ support for this "new" concept to the lexer, parser, AST, and LLVM code emitter.
 it shows how easy it is to "grow" a language over time, incrementally extending it as new ideas are
 discovered.
 
-Before we get going on "how" we add this extension, lets talk about "what" we want. The basic idea is that we
+Before we get going on "how" we add this extension, let's talk about "what" we want. The basic idea is that we
 want to be able to write this sort of thing:
 
 ```python
@@ -1361,7 +1361,7 @@ is the most interesting part of the if/then/else example, because this is where 
 concepts. All of the code above has been thoroughly
 described in previous chapters.
 
-To motivate the code we want to produce, lets take a look at a simple example. Consider:
+To motivate the code we want to produce, let's take a look at a simple example. Consider:
 
 ```python
 extern foo();
@@ -1439,7 +1439,7 @@ and accept that you don't need SSA construction to handle this case. For #2, you
 techniques that we will describe for #1, or you can insert Phi nodes directly, if convenient. In this case, it
 is really really easy to generate the Phi node, so we choose to do it directly.
 
-Okay, enough of the motivation and overview, lets generate code!
+Okay, enough of the motivation and overview, let's generate code!
 
 In order to generate code for this, we implement the Codegen method for ``If`` node:
 
@@ -1485,7 +1485,7 @@ We start by creating three blocks.
 ```
 
 Next emit the expression for the condition, then compare that value to zero to get a truth value as a 1-bit
-(i.e. bool) value. We end this entry block by emitting the conditional branch that chooses between them the
+(i.e. bool) value. We end this entry block by emitting the conditional branch that chooses between the
 two cases.
 
 ```haskell
@@ -1514,7 +1514,7 @@ rule, the verifier will emit an error.
 The final line here is quite subtle, but is very important. The basic issue is that when we create the Phi
 node in the merge block, we need to set up the block/value pairs that indicate how the Phi will work.
 Importantly, the Phi node expects to have an entry for each predecessor of the block in the CFG. Why then, are
-we getting the current block when we just set it block 3 lines above? The problem is that the``ifthen``
+we getting the current block when we just set it 3 lines above? The problem is that the``ifthen``
 expression may actually itself change the block that the Builder is emitting into if, for example, it contains
 a nested "if/then/else" expression. Because calling ``cgen`` recursively could arbitrarily change the notion of
 the current block, we are required to get an up-to-date value for code that will set up the Phi node.
@@ -1547,7 +1547,7 @@ we'll add another useful expression that is familiar from non-functional languag
 ‘for' Loop Expressions
 ----------------------
 
-Now that we know how to add basic control flow constructs to the language, we have the tools to add more powerful things. Lets add something more aggressive, a ‘for' expression:
+Now that we know how to add basic control flow constructs to the language, we have the tools to add more powerful things. Let's add something more aggressive, a ‘for' expression:
 
 ```haskell
 extern putchard(char)
@@ -1581,7 +1581,7 @@ lexer = Tok.makeTokenParser style
              }
 ```
 
-As before, lets talk about the changes that we need to Kaleidoscope to support this. The AST node is just as
+As before, let's talk about the changes that we need to Kaleidoscope to support this. The AST node is just as
 simple. It basically boils down to capturing the variable name and the constituent expressions in the node.
 
 ```haskell
@@ -1703,7 +1703,7 @@ Now that the "preheader" for the loop is set up, we switch to emitting code for 
   cgen body                      -- Generate the loop body
 ```
 
-The body will contain the iteration variable scoped with it's code generation. After loading it's current
+The body will contain the iteration variable scoped with its code generation. After loading its current
 state we increment it by the step value and store the value.
 
 ```haskell
@@ -1895,7 +1895,7 @@ data Expr =
   | UnaryDef Name [Name] Expr
 ```
 
-The parser extension is straightforward and essentially a function definition with a few slight change. Note
+The parser extension is straightforward and essentially a function definition with a few slight changes. Note
 that we capture the string value of the operator as given to us by the parser.
 
 ```haskell
@@ -1919,7 +1919,7 @@ codegenTop (S.BinaryDef name args body) =
   codegenTop $ S.Function ("binary" ++ name) args body
 ```
 
-Now for our binary operator instead of failing with the presence of a binary operator not declared in our
+Now for our binary operator, instead of failing with the presence of a binary operator not declared in our
 ``binops`` list, we instead create a call to a named "binary" function with the operator name.
 
 ```haskell
@@ -1971,7 +1971,7 @@ codegenTop (S.UnaryDef name args body) =
   codegenTop $ S.Function ("unary" ++ name) args body
 ```
 
-Up until now we have not have had any unary operators so code generation we will simply always search for an
+Up until now we have not have had any unary operators so for code generation we will simply always search for an
 implementation as a function.
 
 ```haskell
@@ -2119,7 +2119,7 @@ def mandel(realstart imagstart realmag imagmag)
 ```
 
 
-Given this, we can try plotting out the mandelbrot set! Lets try it out:
+Given this, we can try plotting out the mandelbrot set! Let's try it out:
 
 ```python
 
@@ -2394,12 +2394,12 @@ extremely good reason not to. Using this technique is:
   debug info.
 
 If nothing else, this makes it much easier to get our front-end up and running, and is very simple to
-implement. Lets extend Kaleidoscope with mutable variables now!
+implement. Let's extend Kaleidoscope with mutable variables now!
 
 Mutable Variables
 -----------------
 
-Now that we know the sort of problem we want to tackle, lets see what this looks like in the context of our little Kaleidoscope language. We're going to add two features:
+Now that we know the sort of problem we want to tackle, let's see what this looks like in the context of our little Kaleidoscope language. We're going to add two features:
 
 * The ability to mutate variables with the ‘=' operator.
 * The ability to define new variables.
@@ -2448,7 +2448,7 @@ data Expr
   deriving (Eq, Ord, Show)
 ```
 
-The parser for it will allow for multiple declarations on a single and right fold the AST node bodies,
+The parser for it will allow for multiple declarations on a single line and right fold the AST node bodies,
 allowing us to use variables declared earlier in the list in subsequent declarations (i.e.
 ``var x = 3, y = x + 1``).
 
@@ -2659,7 +2659,7 @@ basics, I strongly encourage you to take the code and hack on it. For example, t
   building a compiler for a specific language. However, there are many other domains that can use compiler
   technology that are not typically considered. For example, LLVM has been used to implement OpenGL graphics
   acceleration, translate C++ code to ActionScript, and many other cute and clever things. Maybe you will be
-  the first to JIT compile a regular expression interpreter into native code with LLVM?  Have fun try doing
+  the first to JIT compile a regular expression interpreter into native code with LLVM?  Have fun and try doing
   something crazy and unusual. Building a language like everyone else always has, is much less fun than trying
   something a little crazy or off the wall and seeing how it turns out. If you get stuck or want to talk about
   it, feel free to email the llvmdev mailing list: it has lots of people who are interested in languages and

--- a/tutorial.md
+++ b/tutorial.md
@@ -218,7 +218,7 @@ module.
 ``float (i32)``    A function taking a ``i32`` and returning a 32-bit floating point ``float``
 ``<4 x i32>``      A width 4 vector of 32-bit integer values.
 ``{i32, double}``  A struct of a 32-bit integer and a double.
-``<{i8*, i32}>``   A packed structure of a integer pointer and 32-bit integer.
+``<{i8*, i32}>``   A packed structure of an integer pointer and 32-bit integer.
 ``[4 x i32]``      An array of four i32 values.
 
 While LLVM is normally generated procedurally we can also write it by hand. For example consider the following
@@ -287,10 +287,10 @@ parser. The *Parsec* library exposes a collection of combinators:
 
               Combinators   
 -----------   ------------
-``<|>``       The choice operator tries to parse the first argument before proceeding to the second. Can be chained sequentially to a generate a sequence of options.
+``<|>``       The choice operator tries to parse the first argument before proceeding to the second. Can be chained sequentially to generate a sequence of options.
 ``many``      Consumes an arbitrary number of patterns matching the given pattern and returns them as a list.
 ``many1``     Like many but requires at least one match. 
-``optional``  Optionally parses a given pattern returning it's value as a Maybe.
+``optional``  Optionally parses a given pattern returning its value as a Maybe.
 ``try``       Backtracking operator will let us parse ambiguous matching expressions and restart with a different pattern.
 
 The Lexer
@@ -334,7 +334,7 @@ commaSep = Tok.commaSep lexer
 ```
 
 Lastly our lexer requires that several tokens be reserved and not used
-identifiers, we reference these as separately.
+as identifiers, we reference these as separately.
 
 **reserved**: ``def``, ``extern``
 
@@ -371,7 +371,7 @@ This is all (intentionally) rather straight-forward: variables capture the varia
 capture their operation (e.g. `Plus`, `Minus`, ...), and calls capture a function name as well as a list of any
 argument expressions.
 
-We create Parsec parser which will scan a input source and unpack it into our ``Expr`` type. The code composes
+We create Parsec parser which will scan an input source and unpack it into our ``Expr`` type. The code composes
 within the ``Parser`` to generate the resulting parser which is then executed using the ``parse`` function.
 
 ~~~~ {.haskell include="src/chapter2/Parser.hs"}
@@ -441,10 +441,10 @@ The LLVM bindings for Haskell are split across two packages:
 
 llvm-general-pure does not require the LLVM libraries be available on the system.
 
-On Hackage there is an older version of llvm bindings named ``llvm`` and ``llvm-base`` which should likely be
-avoided since they has not been updated since it's development a few years ago.
+On Hackage there is an older version of the LLVM bindings named ``llvm`` and ``llvm-base`` which should likely be
+avoided since they have not been updated since their development a few years ago.
 
-As an aside the GHCi can have issues with the FFI and can lead to errors when working with ``llvm-general``.
+As an aside, the GHCi can have issues with the FFI and can lead to errors when working with ``llvm-general``.
 If you end up with errors like the following, then you are likely trying to use ``GHCi`` or ``runhaskell`` and
 it is unable to link against your LLVM library. Instead compile with standalone ``ghc``.
 
@@ -598,7 +598,7 @@ collection of helper functions to push instructions onto the stack held within o
 
 Instructions in LLVM are either numbered sequentially (``%0``, ``%1``, ...) or given explicit variable names (``%a``,
 ``%foo``, ..). For example the arguments to the following function are named values, while the result of the add
-instructions unnamed.
+instruction is unnamed.
 
 ```perl
 define i32 @add(i32 %a, i32 %b) {
@@ -609,8 +609,8 @@ define i32 @add(i32 %a, i32 %b) {
 
 In the implementation of llvm-general both these types are represented in a sum type containing the
 constructors ``UnName`` and ``Name``. For most of our purpose we will simply use numbered expressions and map
-them numbers to identifiers with in our symbol table. Every instruction added will increment the internal
-counter, to accomplish we add a fresh name supply.
+them numbers to identifiers within our symbol table. Every instruction added will increment the internal
+counter, to accomplish this we add a fresh name supply.
 
 ```haskell
 fresh :: Codegen Word
@@ -685,7 +685,7 @@ getvar var = do
     Nothing -> error $ "Local variable not in scope: " ++ show var
 ```
 
-Now that we have a way of naming instructions we'll create a internal function to take a llvm -general AST
+Now that we have a way of naming instructions we'll create an internal function to take a llvm-general AST
 node and push it on the current basic block stack. We'll return the left hand side reference of the
 instruction. Instructions will come in two flavors, *instructions* and *terminators*. Every basic block has a
 unique terminator and every last basic block in a function must terminate in a ``ret``.
@@ -865,7 +865,7 @@ cgen (S.BinaryOp op a b) = do
 
 Putting everything together we find that we nice little minimal language that supports both function
 abstraction and basic arithmetic. The final step is to hook into LLVM bindings to generate a string
-representation of the LLVM IR which we'll print our the string on each action in the REPL. We'll
+representation of the LLVM IR which will print out the string on each action in the REPL. We'll
 discuss these functions in more depth in the next chapter.
 
 ```haskell
@@ -1110,9 +1110,9 @@ about the various passes is available, but it isn't very complete. Another good 
 looking at the passes that Clang runs to get started. The “opt” tool allows us to experiment with passes from
 the command line, so we can see if they do anything.
 
-One important optimization pass is a "analysis pass" which will validate that the internal IR is well-formed.
+One important optimization pass is an "analysis pass" which will validate that the internal IR is well-formed.
 Since it quite possible (even easy!) to construct nonsensical or unsafe IR it is very good practice to
-validate our IR before attempting to optimize or execute it. To do we simply invoke the verify function with
+validate our IR before attempting to optimize or execute it. To do so, we simply invoke the verify function with
 our active module.
 
 ```haskell
@@ -1242,13 +1242,13 @@ name, and even allows us JIT compile functions lazily the first time they're cal
 
 One interesting application of this is that we can now extend the
 language by writing arbitrary C code to implement operations. For
-example, if create a shared library ``cbits.so``:
+example, we create a shared library ``cbits.so``:
 
 ~~~~ {.cpp include="src/chapter4/cbits.c"}
 ~~~~
 
 Compile this with your favorite C compiler. We can then link this into our Haskell binary by simply including
-it along side the rest of the Haskell source files
+it alongside the rest of the Haskell source files:
 
 ```bash
 $ ghc cbits.so --make Main.hs -o Main


### PR DESCRIPTION
I took the liberty of fixing some typos and small grammar things (e.g. missing/duplicated words that disrupt the reading flow, nothing major) while reading through the (excellent!) tutorial.