### PR TITLE
Make appending instructions to blocks more efficient

### DIFF
--- a/src/chapter3/Codegen.hs
+++ b/src/chapter3/Codegen.hs
@@ -117,7 +117,7 @@ createBlocks :: CodegenState -> [BasicBlock]
 createBlocks m = map makeBlock $ sortBlocks $ Map.toList (blocks m)
 
 makeBlock :: (Name, BlockState) -> BasicBlock
-makeBlock (l, (BlockState _ s t)) = BasicBlock l s (maketerm t)
+makeBlock (l, (BlockState _ s t)) = BasicBlock l (reverse s) (maketerm t)
   where
     maketerm (Just x) = x
     maketerm Nothing = error $ "Block has no terminator: " ++ (show l)
@@ -146,7 +146,7 @@ instr ins = do
   let ref = (UnName n)
   blk <- current
   let i = stack blk
-  modifyBlock (blk { stack = i ++ [ref := ins] } )
+  modifyBlock (blk { stack = (ref := ins) : i } )
   return $ local ref
 
 terminator :: Named Terminator -> Codegen (Named Terminator)

--- a/src/chapter4/Codegen.hs
+++ b/src/chapter4/Codegen.hs
@@ -117,7 +117,7 @@ createBlocks :: CodegenState -> [BasicBlock]
 createBlocks m = map makeBlock $ sortBlocks $ Map.toList (blocks m)
 
 makeBlock :: (Name, BlockState) -> BasicBlock
-makeBlock (l, (BlockState _ s t)) = BasicBlock l s (maketerm t)
+makeBlock (l, (BlockState _ s t)) = BasicBlock l (reverse s) (maketerm t)
   where
     maketerm (Just x) = x
     maketerm Nothing = error $ "Block has no terminator: " ++ (show l)
@@ -146,7 +146,7 @@ instr ins = do
   let ref = (UnName n)
   blk <- current
   let i = stack blk
-  modifyBlock (blk { stack = i ++ [ref := ins] } )
+  modifyBlock (blk { stack = (ref := ins) : i } )
   return $ local ref
 
 terminator :: Named Terminator -> Codegen (Named Terminator)

--- a/src/chapter5/Codegen.hs
+++ b/src/chapter5/Codegen.hs
@@ -117,7 +117,7 @@ createBlocks :: CodegenState -> [BasicBlock]
 createBlocks m = map makeBlock $ sortBlocks $ Map.toList (blocks m)
 
 makeBlock :: (Name, BlockState) -> BasicBlock
-makeBlock (l, (BlockState _ s t)) = BasicBlock l s (maketerm t)
+makeBlock (l, (BlockState _ s t)) = BasicBlock l (reverse s) (maketerm t)
   where
     maketerm (Just x) = x
     maketerm Nothing = error $ "Block has no terminator: " ++ (show l)
@@ -146,7 +146,7 @@ instr ins = do
   let ref = (UnName n)
   blk <- current
   let i = stack blk
-  modifyBlock (blk { stack = i ++ [ref := ins] } )
+  modifyBlock (blk { stack = (ref := ins) : i } )
   return $ local ref
 
 terminator :: Named Terminator -> Codegen (Named Terminator)

--- a/src/chapter6/Codegen.hs
+++ b/src/chapter6/Codegen.hs
@@ -117,7 +117,7 @@ createBlocks :: CodegenState -> [BasicBlock]
 createBlocks m = map makeBlock $ sortBlocks $ Map.toList (blocks m)
 
 makeBlock :: (Name, BlockState) -> BasicBlock
-makeBlock (l, (BlockState _ s t)) = BasicBlock l s (maketerm t)
+makeBlock (l, (BlockState _ s t)) = BasicBlock l (reverse s) (maketerm t)
   where
     maketerm (Just x) = x
     maketerm Nothing = error $ "Block has no terminator: " ++ (show l)
@@ -146,7 +146,7 @@ instr ins = do
   let ref = (UnName n)
   blk <- current
   let i = stack blk
-  modifyBlock (blk { stack = i ++ [ref := ins] } )
+  modifyBlock (blk { stack = (ref := ins) : i } )
   return $ local ref
 
 terminator :: Named Terminator -> Codegen (Named Terminator)

--- a/src/chapter7/Codegen.hs
+++ b/src/chapter7/Codegen.hs
@@ -128,7 +128,7 @@ createBlocks :: CodegenState -> [BasicBlock]
 createBlocks m = map makeBlock $ sortBlocks $ Map.toList (blocks m)
 
 makeBlock :: (Name, BlockState) -> BasicBlock
-makeBlock (l, (BlockState _ s t)) = BasicBlock l s (maketerm t)
+makeBlock (l, (BlockState _ s t)) = BasicBlock l (reverse s) (maketerm t)
   where
     maketerm (Just x) = x
     maketerm Nothing = error $ "Block has no terminator: " ++ (show l)
@@ -165,7 +165,7 @@ instr ins = do
   let ref = (UnName n)
   blk <- current
   let i = stack blk
-  modifyBlock (blk { stack = i ++ [ref := ins] } )
+  modifyBlock (blk { stack = (ref := ins) : i } )
   return $ local ref
 
 terminator :: Named Terminator -> Codegen (Named Terminator)

--- a/tutorial.md
+++ b/tutorial.md
@@ -697,7 +697,7 @@ instr ins = do
   blk <- current
   let i = stack blk
   let ref = (UnName n)
-  modifyBlock $ blk { stack = i ++ [ref := ins] }
+  modifyBlock $ blk { stack = (ref := ins) : i }
   return $ local ref
 
 terminator :: Named Terminator -> Codegen (Named Terminator)


### PR DESCRIPTION
Previously, this ran in O(n^2) (where n is the number of instructions
to be added) as new instructions were inserted at the end of the list
representing the instruction stack. As this list grows longer, appends
become more expensive, involving a bunch of copying and GC overhead.
This change switches to prepending instructions to the stack (with a
reverse call before converting to BasicBlock), which is an O(1)
operation, yielding O(n) for our n instructions.

_I ran into this issue when working on a compiler based on the framework presented in this tutorial. This fix reduced compile times by more than 99% for my main use case, so sharing it might help others who base their compiler projects on this codebase as well._

_If this pull request is accepted, I'll send a pull request containing the same changes to the [llvm-hs/llvm-hs-kaleidoscope](https://github.com/llvm-hs/llvm-hs-kaleidoscope) repository._